### PR TITLE
Fix KaraokeLyricsView reverts its background on program restart.

### DIFF
--- a/LyricsX/Controller/DesktopLyricsController.swift
+++ b/LyricsX/Controller/DesktopLyricsController.swift
@@ -54,6 +54,7 @@ class DesktopLyricsViewController: NSViewController {
         lyricsView.bind("fontSize", to: dfs, withKeyPath: DesktopLyricsFontSize.rawValue, options: nil)
         lyricsView.bind("textColor", to: dfs, withKeyPath: DesktopLyricsColor.rawValue, options: transOpt)
         lyricsView.bind("shadowColor", to: dfs, withKeyPath: DesktopLyricsShadowColor.rawValue, options: transOpt)
+        lyricsView.bind("fillColor", to: dfs, withKeyPath: DesktopLyricsBackgroundColor.rawValue, options: transOpt)
         
         lyricsHeightConstraint.constant = CGFloat(Preference[DesktopLyricsHeighFromDock])
         


### PR DESCRIPTION
I set the background of my KaraokeLyricsView to transparent. However it reverts to grey after each program restart.
I think it's probably missing this line in DesktopLyricsController.